### PR TITLE
Remove cursor:pointer hover effect on cell

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -65,7 +65,6 @@ p.game-control {
 }
 
 .cell:hover {
-	cursor: pointer;
 	border-color: #ba0000;
 }
 


### PR DESCRIPTION
Explanation
-----
It would be better if the cursor remained an arrow when you hover your mouse over the cell. So I suggest removing `cursor:pointer` property from `.cell:hover` selector in `src/App/App.css` for better user experience.
![screenshot](https://user-images.githubusercontent.com/18328279/28074066-4e1b84e4-6660-11e7-9249-cfee84a46be0.png)
